### PR TITLE
Update for Lumen > v5.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 本項目修改 [Captcha for Laravel 5](https://github.com/mewebstudio/captcha) 和 [lumen-captcha](https://github.com/aishan/lumen-captcha)
 
+## Requirement
+Lumen version >= v5.5
 
 
 ## Preview

--- a/src/CaptchaServiceProvider.php
+++ b/src/CaptchaServiceProvider.php
@@ -19,8 +19,8 @@ class CaptchaServiceProvider extends ServiceProvider {
     public function boot()
     {
         // HTTP routing
-        $this->app->get('captchaInfo[/{type}]', 'Yangbx\CaptchaLumen\LumenCaptchaController@getCaptchaInfo');
-        $this->app->get('captcha/{type}/{captchaId}', 'Yangbx\CaptchaLumen\LumenCaptchaController@getCaptcha');
+        $this->app->router->get('captchaInfo[/{type}]', 'Yangbx\CaptchaLumen\LumenCaptchaController@getCaptchaInfo');
+        $this->app->router->get('captcha/{type}/{captchaId}', 'Yangbx\CaptchaLumen\LumenCaptchaController@getCaptcha');
 
         // Validator extensions
         $this->app['validator']->extend('captcha', function($attribute, $value, $parameters)


### PR DESCRIPTION
Start from Lumen 5.5, routing use "$this->app->router" instead of "$app" variable.

ps: "$this->app->router" will be passed to "routes/web.php" at "bootstrap/app.php", therefore "routes/web.php" using "$router" at Lumen v5.5.